### PR TITLE
Removing numba from main data path.

### DIFF
--- a/tests/test_surya.py
+++ b/tests/test_surya.py
@@ -148,7 +148,7 @@ def dataloader(dataset) -> DataLoader:
         dataset,
         shuffle=False,
         batch_size=1,
-        num_workers=0,
+        num_workers=2,
         prefetch_factor=None,
         pin_memory=True,
         drop_last=False,


### PR DESCRIPTION
The inference test would hang on certain GPU clusters except for `num_workers=0`. I.e. when data loading happened outside the main process. It turns out that this is related to `numba` being used for a fast data transform. This patch removes that from the main process. I.e. there is a new method `transform` that only leverages numpy. It replaces `fast_transform` in the dataset; but `fast_transform` is still in the codebase.

In theory one could add a flag to the dataset to decide which method to use. For now let's leave it at this.