### PR TITLE
Relative path in csv support

### DIFF
--- a/surya/datasets/helio.py
+++ b/surya/datasets/helio.py
@@ -481,7 +481,7 @@ class HelioNetCDFDataset(Dataset):
         """
         self.logger.info(f"Reading file {filepath}.")
         
-        if self.sdo_data_root_path:
+        if self.sdo_data_root_path and not os.path.isabs(filepath):
             filepath = os.path.join(self.sdo_data_root_path, filepath)
         
         with xr.open_dataset(


### PR DESCRIPTION
While running downstream tasks we fetch the SDO data from [nasa-ibm-ai4science/SDO_training](https://huggingface.co/datasets/nasa-ibm-ai4science/SDO_training/blob/main/train_index_surya_1_0.csv). Here we only have relative paths. I have added support that will also be able to handle relative path only when we also provide root path + csv with relative paths.

This doesn't change the default behaviour. Hence all the current test and code will work as it is without changes.